### PR TITLE
Fix non-Youtube player test

### DIFF
--- a/test/jquery_player_test.js
+++ b/test/jquery_player_test.js
@@ -15,12 +15,9 @@ describe("jquery.player tests (integration)", function () {
     expect(document.querySelectorAll("#wrapper").length).toBe(1);
   });
 
-  it("should not call the YoutubePlayer constructor when using Vimeo", function () {
-    var videoLink, youtubeId;
-
-    videoLink = document.createElement("a");
-    videoLink.href = "http://vimeo.com/36579366";
-    youtubeId = videoLink.href.split("=")[1];
+  it("should not call the YoutubePlayer constructor when not using YouTube", function () {
+    var videoLink = document.createElement("a");
+    videoLink.href = "http://www.some-website.com/some-html5-video.mpg";
     wrapper.appendChild(videoLink);
     spyOn(window.NOMENSA.player, "YoutubePlayer");
     holder = $("<span></span>");
@@ -30,7 +27,7 @@ describe("jquery.player tests (integration)", function () {
     // Initialise the player.
     holder.player({
       id: 'youtube1',
-      media: youtubeId,
+      media: 'some-html5-video.mpg',
       url: videoLink.href
     });
 


### PR DESCRIPTION
The default player doesn’t handle a non Youtube URL unless it has a playable HTML5 media type.

The old test passed in `media: undefined` (the ID lookup from a Vimeo URL never worked). which couldn’t be found in the compatible list of types. When the supplied URL correctly gets past the "is this Youtube?" check, the player tries to create an HTML5 media player without a valid file/mime type and errors.

There's no concept of a Vimeo player in the TestRunner or specs, those source files aren't included.

* Refactor test to be a generic "non-Youtube" test with a filetype

cc @dsingleton @tombye 